### PR TITLE
Force python version 2

### DIFF
--- a/bin/otrverwaltung
+++ b/bin/otrverwaltung
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 ### BEGIN LICENSE
 # Copyright (C) 2010 Benjamin Elbers <elbersb@gmail.com>


### PR DESCRIPTION
A lot of distros switched or are switching to python 3.x as primary python implementation recently, PyGTK however is on most distros only available for python 2.x. This change should force python 2.x instead of the generic wrapper which may point to python 3. Tested on arch,gentoo and ubuntu.