### PR TITLE
Vorläufiger Support für Sniplist

### DIFF
--- a/data/ui/PreferencesWindow.glade
+++ b/data/ui/PreferencesWindow.glade
@@ -1279,7 +1279,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="xalign">0</property>
-                        <property name="label" translatable="yes">Cutlist-Server:</property>
+			<property name="label" translatable="yes">Cutlist-Server/persönliche URL:</property>
                       </object>
                       <packing>
                         <property name="x_options">GTK_FILL</property>

--- a/otrverwaltung/cutlists.py
+++ b/otrverwaltung/cutlists.py
@@ -90,7 +90,7 @@ class Cutlist:
         headers = { 'Content-Type': 'multipart/form-data; boundary=%s' % boundary }
 
         try:
-            connection.request('POST', server + "index.php?upload=2", body, headers)
+            connection.request('POST', server + "", body, headers)
         except Exception, error_message:
            return error_message       
 

--- a/otrverwaltung/cutlists.py
+++ b/otrverwaltung/cutlists.py
@@ -228,7 +228,6 @@ class Cutlist:
                 "FramesPerSecond=%s\n" % str(self.fps),
                 "IntendedCutApplicationName=%s\n" % intended_app_name,
                 "IntendedCutApplication=%s\n" % self.intended_app,
-                "IntendedCutApplicationVersion=\n",
                 "VDUseSmartRendering=%s\n" % str(int(self.smart)),
                 "VDSmartRenderingCodecFourCC=0x53444646\n",
                 "VDSmartRenderingCodecVersion=0x00000000\n",


### PR DESCRIPTION
Nachdem nun cutlist.at abgeschaltet wurde hat Sniplist unter selber URL den Betrieb aufgenommen. Der Download ist über die alten Adressen möglich, diese Änderungen ermöglichen zusätzlich einen Cutlist-Upload. Rating ist noch nicht berücksichtigt.